### PR TITLE
fix value comparison logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,8 +62,8 @@ function createCombineObserver(targetContexts, baseObject) {
     // Compares the `newValues` and `prevValues` to confirm position has changed
     var changedArgPositions = newValues.map(function(value, i) {
       return prevValues.indexOf(value) !== i ? i : null;
-    }).filter(function(value) {
-      return value != null;
+    }).filter(function(i) {
+      return i != null;
     });
 
     // To update only the changed arguments

--- a/index.js
+++ b/index.js
@@ -62,6 +62,8 @@ function createCombineObserver(targetContexts, baseObject) {
     // Compares the `newValues` and `prevValues` to confirm position has changed
     var changedArgPositions = newValues.map(function(value, i) {
       return prevValues.indexOf(i) !== value ? i : null;
+    }).filter(function(value) {
+      return value != null;
     });
 
     // To update only the changed arguments

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function createCombineObserver(targetContexts, baseObject) {
 
     // Compares the `newValues` and `prevValues` to confirm position has changed
     var changedArgPositions = newValues.map(function(value, i) {
-      return prevValues.indexOf(i) !== value ? i : null;
+      return prevValues.indexOf(value) !== i ? i : null;
     }).filter(function(value) {
       return value != null;
     });


### PR DESCRIPTION
This bug came to my attention when using `combineTemplate` with `Kefir.interval(t, -1)`, because -1 is what `indexOf` returns when the value does not exist.
